### PR TITLE
provide custom file extensions to modules

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -17,6 +17,22 @@ return {
   -- modules that should be used for parsing
   modules     = { "html", "markdown", "git", "gallery", "download", "footer" },
 
+  --[[
+  -- module options
+  html = {
+    extensions = { ".xhtml", ".html" }
+  },
+  markdown = {
+    extensions = { ".md" }
+  },
+  gallery = {
+    extensions = { ".png", ".jpg" }
+  },
+  download = {
+    extensions = { ".pdf", ".xz", ".zstd" }
+  },
+  ]]--
+
   -- define default colors
   colors      = {
     ["accent"]      = "#3a5",

--- a/config_dark.lua
+++ b/config_dark.lua
@@ -17,6 +17,22 @@ return {
   -- modules that should be used for parsing
   modules     = { "html", "markdown", "git", "gallery", "download", "footer" },
 
+  --[[
+  -- module options
+  html = {
+    extensions = { ".xhtml", ".html" }
+  },
+  markdown = {
+    extensions = { ".md" }
+  },
+  gallery = {
+    extensions = { ".png", ".jpg" }
+  },
+  download = {
+    extensions = { ".pdf", ".xz", ".zstd" }
+  },
+  ]]--
+
   -- define default colors
   colors      = {
     ["accent"]      = "#3fc",

--- a/webls.lua
+++ b/webls.lua
@@ -66,7 +66,7 @@ local icons = {
 
 local parser = {
   ["markdown"] = {
-    extensions = { ".md", ".txt" },
+    extensions = config.markdown and config.markdown.extensions or { ".md", ".txt" },
     prepare = function(self, path, name, fin, fout)
       local file = io.open(fin, "rb")
       local content = file:read("*all")
@@ -102,7 +102,7 @@ local parser = {
   },
 
   ["html"] = {
-    extensions = { ".html", ".htm" },
+    extensions = config.html and config.html.extensions or { ".html", ".htm" },
     prepare = function(self, path, name, fin, fout)
       local file = io.open(fin, "rb")
       local content = file:read("*all")
@@ -126,7 +126,7 @@ local parser = {
   },
 
   ["gallery"] = {
-    extensions = { ".png", ".jpg", ".jpeg", ".webp", ".gif" },
+    extensions = config.gallery and config.gallery.extensions or { ".png", ".jpg", ".jpeg", ".webp", ".gif" },
     prepare = function(self, path, name, fin, fout)
       self.cache = self.cache or {}
       self.cache[path] = self.cache[path] or {}
@@ -148,7 +148,7 @@ local parser = {
   },
 
   ["download"] = {
-    extensions = { ".tar", ".gz", ".bz2", ".xz", ".zip", ".rar" },
+    extensions = config.download and config.download.extensions or { ".tar", ".gz", ".bz2", ".xz", ".zip", ".rar" },
     prepare = function(self, path, name, fin, fout)
       self.cache = self.cache or {}
       self.cache[path] = self.cache[path] or {}


### PR DESCRIPTION
in some cases it may be usefule to adapt module specific settings like file extensions
to provide downloads of different file types than the ones listed in webls or
exclude files like `CMakeLists.txt` in a git-submodule added to the content directory